### PR TITLE
Explain grammar details

### DIFF
--- a/src/ucumvert/parser.py
+++ b/src/ucumvert/parser.py
@@ -73,10 +73,14 @@ logger = logging.getLogger(__name__)
 # and fixes some more edge cases not present in the official examples.
 #
 # Changes made:
-# - to fix "100/{cells}" issue, we moved FACTOR from component to the simple_unit rule
-# - to fix "(8.h){shift}" issue, we moved "(" term ")" from component to the annotatable rule
+# - To fix "100/{cells}" issue, we moved FACTOR from component to the simple_unit rule
+# - To fix "(8.h){shift}" issue, we moved "(" term ")" from component to the annotatable rule
 # - Don't allow "0" as EXPONENT or FACTOR, see https://github.com/ucum-org/ucum/issues/121
-
+# - Don't allow curly braces {} inside of annotation STRING (ascii 123 and 125). Without this
+#   or escaping rules the end of annotation STRING is ambiguous.
+# - Move term from component rule to annotatable rule. Add maint_term and component to
+#   annotatable rule. These changes solve various annotation issues with the original
+#   grammar (e.g. "100{pc}", "(/m){ann}", "{ann1}{ann2}").
 # - Distinguish short prefixes (1 char) form long ones to handle parsing of "dar" as deci-are
 #   instead of deca-r which does not exist.
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -22,9 +22,10 @@ ucum_examples_valid.update(
         "x3": "(/s)",  # bracketed unary divide
         "x4": "(/s2{sunit_s2}.(10{factor}.m{sunit_m}){term}){mterm}",  # annotations everywhere
         "x5": "dar",  # ambiguous prefix-unit combo: deci-are vs. deka-r (unit "r" does not exist)
-        "x6": "{}/m",
-        "x7": "{}",
+        "x6": "{}/m",  # operator between annotation and unit
+        "x7": "{}",  # annotation only
         "x8": "{/ann1/2.g}/m",  # operators in annotation
+        "x9": "{ann1}/{ann2}",  # annotations only with operator
     }
 )
 


### PR DESCRIPTION
The BNF grammar in the UCUM specification is not said to be correct but just an example. In order to fulfill the specification written in the text, we had to adapt the rules. This PR adds notes to explain the changes (as comment in code).

This also adds another edge case to tests which is parsed as it should. (from https://github.com/ucum-org/ucum/issues/157)